### PR TITLE
Minor cleanup, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Lua library to serialize table in string in Dual Universe to improve performan
 # Documentation
 #### serialize(*table* t)
 Serialize a table **t** and return a string.
-*Tables and arrays are supported, not mixed table.*
+*Tables and arrays are supported, not mixed table.* See [serializer_spec.lua](serializer_spec.lua) for supported and unsupported cases.
 
 #### deserialize(*string* s)
 Deserialize a serialized table as string **s** and return the table.

--- a/serializer.lua
+++ b/serializer.lua
@@ -48,7 +48,6 @@ local function internalSerialize(v,tC,t)
     t[tC]=v and 'true' or 'false'
     return tC+1
   end
-  return tC
 end
 function serialize(v)
   local t={}

--- a/serializer.lua
+++ b/serializer.lua
@@ -51,56 +51,56 @@ local function internalSerialize(v,tC,t)
   return tC
 end
 function serialize(v)
-    local t={}
-    local tC=1
-    local check = type(v)
-    local intSerial=internalSerialize
-    if check=='table' then
-        t[tC]='{'
-        tC=tC+1
-        local tempC=tC
-        if #v==0 then
-            for k,e in pairs(v) do
-              if type(k)~='number' then
-                t[tempC]=k
-                t[tempC+1]='='
-                tempC=tempC+2
-              else
-                t[tempC]='['
-                t[tempC+1]=k
-                t[tempC+2]=']='
-                tempC=tempC+3
-              end
-                tempC=intSerial(e,tempC,t)
-                t[tempC]=','
-                tempC=tempC+1
-            end
+  local t={}
+  local tC=1
+  local check = type(v)
+  local intSerial=internalSerialize
+  if check=='table' then
+    t[tC]='{'
+    tC=tC+1
+    local tempC=tC
+    if #v==0 then
+      for k,e in pairs(v) do
+        if type(k)~='number' then
+          t[tempC]=k
+          t[tempC+1]='='
+          tempC=tempC+2
         else
-            for k,e in pairs(v) do
-                tempC=intSerial(e,tempC,t)
-                t[tempC]=','
-                tempC=tempC+1
-            end
+          t[tempC]='['
+          t[tempC+1]=k
+          t[tempC+2]=']='
+          tempC=tempC+3
         end
-        if tempC==tC then
-            t[tempC]='}'
-        else
-            t[tempC-1]='}'
-        end
-    elseif check=='string' then
-        t[tC]=sFormat("%q",v)
-    elseif check=='number' then
-        t[tC]=tostring(v)
+        tempC=intSerial(e,tempC,t)
+        t[tempC]=','
+        tempC=tempC+1
+      end
     else
-        t[tC]=v and 'true' or 'false'
+      for k,e in pairs(v) do
+        tempC=intSerial(e,tempC,t)
+        t[tempC]=','
+        tempC=tempC+1
+      end
     end
+    if tempC==tC then
+      t[tempC]='}'
+    else
+      t[tempC-1]='}'
+    end
+  elseif check=='string' then
+    t[tC]=sFormat("%q",v)
+  elseif check=='number' then
+    t[tC]=tostring(v)
+  else
+    t[tC]=v and 'true' or 'false'
+  end
 
-    return concat(t)
+  return concat(t)
 end
 
 -- Deserialize a string to a table
 function deserialize(s)
-    local f=load('t='..s)
-    f()
-    return t
+  local f=load('t='..s)
+  f()
+  return t
 end

--- a/serializer_spec.lua
+++ b/serializer_spec.lua
@@ -1,0 +1,151 @@
+#!/usr/bin/env lua
+--- Tests for serializer.
+
+local luaunit = require("luaunit")
+require("serializer")
+
+--- Utility function to serialize input, deserialize the result, and compare input to result.
+-- @param input The array, table, or other input to serialize.
+-- @tparam boolean testNotIs True (default) to verify that the deserialized data is not the same reference as the
+--   input. Set to false for primitive types.
+-- @treturn string The serialized string, in case tests on the intermediate state are required.
+local function verifySerializeDeserialize(input, testNotIs)
+  local serialized = serialize(input)
+  local output = deserialize(serialized)
+  if testNotIs == nil or testNotIs then
+    luaunit.assertNotIs(output, input)
+  end
+  luaunit.assertEquals(output, input)
+  return serialized
+end
+
+--- Test serializing basic types by themselves.
+TestSimpleValue = {}
+function TestSimpleValue.testNil()
+  luaunit.skip("Not supported: returns false")
+  local input = nil
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testBooleanFalse()
+  local input = false
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testBooleanTrue()
+  local input = true
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testNumberInteger()
+  local input = 1
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testNumberFloat()
+  local input = 1.2
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testStringBasic()
+  local input = "string"
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testStringSingleQuote()
+  local input = "string with a ' in it"
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testStringDoubleQuote()
+  local input = 'string with a " in it'
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testStringDoubleBrackets()
+  local input = "string with [[ and ]]"
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testStringAllGroupingSymbols()
+  local input = "all the symbols: \" ' [[ ]]"
+  verifySerializeDeserialize(input, false)
+end
+function TestSimpleValue.testTableEmpty()
+  local input = {}
+  verifySerializeDeserialize(input, false)
+end
+
+--- Test serializing arrays.
+TestArray = {}
+function TestArray.testBoolean()
+  local input = {false, true}
+  verifySerializeDeserialize(input)
+end
+function TestArray.testNumberInteger()
+  local input = {1, 2}
+  verifySerializeDeserialize(input)
+end
+function TestArray.testNumberFloat()
+  local input = {1.2, 2.3}
+  verifySerializeDeserialize(input)
+end
+function TestArray.testString()
+  local input = {"string1", "string2"}
+  verifySerializeDeserialize(input)
+end
+function TestArray.testArray()
+  -- second value chosen to hit special handling in recursive call
+  local input = {{"array1"}, {}}
+  verifySerializeDeserialize(input)
+end
+function TestArray.testTable()
+  -- second value chosen to hit special handling in recursive call
+  local input = {{key1 = "table1"}, {[2] = "table2"}}
+  verifySerializeDeserialize(input)
+end
+
+--- Test serializing tables.
+TestTable = {}
+function TestTable.testBooleanKey()
+  luaunit.skip("Not supported: ")
+  local input = {
+    [false] = 1
+  }
+  verifySerializeDeserialize(input)
+end
+function TestTable.testBooleanValue()
+  local input = {bool = true}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testNumberInteger()
+  local input = {[2] = 3}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testNumberFloat()
+  local input = {[2.3] = 3.4}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testString()
+  local input = {key = "value"}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testArrayKey()
+  luaunit.skip("not supported: array as key")
+  local input = {[{"array 1"}] = "value"}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testArrayValue()
+  local input = {array = {"array 2"}}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testTableKey()
+  luaunit.skip("not supported: table as key")
+  local input = {[{key = "value"}] = "value"}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testTableValue()
+  local input = {table = {key = "value"}}
+  verifySerializeDeserialize(input)
+end
+
+--- Test serializing mixed tables.
+TestMixedTable = {}
+function TestTable.testMixedTable()
+  luaunit.skip("not supported: mixed tables")
+  local input = {2, 3, [5] = 7}
+  verifySerializeDeserialize(input)
+end
+
+os.exit(luaunit.LuaUnit.run())


### PR DESCRIPTION
Only actual code change to `serializer.lua` is removing an unreachable line (51) from the end of `internalSerialize`, everything else is just making the indentation consistent at 2 spaces instead of mixed 2 and 4 spaces across the file. Best viewed in a tool that allows you to ignore whitespace, such as git diff -b

Test suite (`serializer_spec.lua`) uses luaunit and fully covers `serializer.lua`, though it has a handful of cases that are skipped due to not currently being supported.