### PR TITLE
Restored sFormat to handle symbols (") in strings

### DIFF
--- a/serializer.lua
+++ b/serializer.lua
@@ -1,4 +1,5 @@
 local concat = table.concat
+local sFormat=string.format
 
 local function internalSerialize(table, tC, t)
     t[tC] = "{"
@@ -9,7 +10,7 @@ local function internalSerialize(table, tC, t)
             hasValue = true
             local keyType = type(key)
             if keyType == "string" then
-                t[tC] = key .. "="
+                t[tC] = sFormat("[%q]=", key)
             elseif keyType == "number" then
                 t[tC] = "[" .. key .. "]="
             elseif keyType == "boolean" then
@@ -23,7 +24,7 @@ local function internalSerialize(table, tC, t)
             if check == "table" then
                 tC = internalSerialize(value, tC, t)
             elseif check == "string" then
-                t[tC] = '"' .. value .. '"'
+                t[tC] = sFormat("%q", value)
             elseif check == "number" then
                 t[tC] = value
             elseif check == "boolean" then
@@ -44,7 +45,7 @@ local function internalSerialize(table, tC, t)
             if check == "table" then
                 tC = internalSerialize(value, tC, t)
             elseif check == "string" then
-                t[tC] = '"' .. value .. '"'
+                t[tC] = sFormat("%q", value)
             elseif check == "number" then
                 t[tC] = value
             elseif check == "boolean" then
@@ -68,7 +69,7 @@ function serialize(value)
     if check == "table" then
         internalSerialize(value, 1, t)
     elseif check == "string" then
-        return '"' .. value .. '"'
+        return sFormat("%q", value)
     elseif check == "number" then
         return value
     elseif check == "boolean" then

--- a/serializer_spec.lua
+++ b/serializer_spec.lua
@@ -85,6 +85,10 @@ function TestArray.testString()
   local input = {"string1", "string2"}
   verifySerializeDeserialize(input)
 end
+function TestArray.testStringSymbols()
+  local input = {"'", '"', "[[", "]]"}
+  verifySerializeDeserialize(input)
+end
 function TestArray.testArray()
   -- second value chosen to hit special handling in recursive call
   local input = {{"array1"}, {}}
@@ -99,7 +103,6 @@ end
 --- Test serializing tables.
 TestTable = {}
 function TestTable.testBooleanKey()
-  luaunit.skip("Not supported: ")
   local input = {
     [false] = 1
   }
@@ -119,6 +122,14 @@ function TestTable.testNumberFloat()
 end
 function TestTable.testString()
   local input = {key = "value"}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testStringSpaces()
+  local input = {["key spaces"] = "value spaces"}
+  verifySerializeDeserialize(input)
+end
+function TestTable.testStringSymbols()
+  local input = {["\"'[[]]"] = "\" ' [[ ]]"}
   verifySerializeDeserialize(input)
 end
 function TestTable.testArrayKey()


### PR DESCRIPTION
Restored string formatting to escape strings properly (so a " in a string doesn't break it).
Also changed the table key handling for string to escape it and put it in brackets to allow any string to be a key, not just single words without symbols.
